### PR TITLE
Add support for multimedia directories, apply latest app example, fix Python call for Bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Bazarr is a companion application to Sonarr and Radarr that manages and download
 - Subtitles upgrade whenever better ones are released
 
 
-**Shipped version:** 1.0.1~ynh1
+**Shipped version:** 1.0.1~ynh2
 
 
 
 ## Screenshots
 
-![](./doc/screenshots/example.jpg)
+![](./doc/screenshots/bazarr.png)
 
 ## Disclaimers / important information
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,13 +20,13 @@ Bazarr is a companion application to Sonarr and Radarr that manages and download
 - Subtitles upgrade whenever better ones are released
 
 
-**Version incluse :** 1.0.1~ynh1
+**Version incluse :** 1.0.1~ynh2
 
 
 
 ## Captures d'écran
 
-![](./doc/screenshots/example.jpg)
+![](./doc/screenshots/bazarr.png)
 
 ## Avertissements / informations importantes
 

--- a/check_process
+++ b/check_process
@@ -20,7 +20,7 @@
 		setup_private=1
 		setup_public=0
 		upgrade=1
-		#upgrade=1	from_commit=CommitHash
+		upgrade=1	from_commit=22445f018b70ed1a89593107afff498b672f93ad
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
@@ -29,6 +29,6 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=CommitHash
-		name=Name and date of the commit.
-		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr&is_public=1&password=pass&port=666&
+	; commit=22445f018b70ed1a89593107afff498b672f93ad
+		name=2022-01-13 v1.0.1~ynh1
+		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&

--- a/check_process
+++ b/check_process
@@ -1,8 +1,3 @@
-# See here for more information
-# https://github.com/YunoHost/package_check#syntax-check_process-file
-
-# Move this file from check_process.default to check_process when you have filled it.
-
 ;; Test complet
 	; pre-install
 #			sudo yunohost domain add arr.domain.tld

--- a/conf/config.ini
+++ b/conf/config.ini
@@ -1,7 +1,7 @@
 [general]
 ip = 127.0.0.1
 port = __PORT__
-base_url = __PATH__
+base_url = __PATH_URL__
 path_mappings = []
 debug = False
 branch = master

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -14,6 +14,8 @@ StandardOutput=append:/var/log/__APP__/__APP__.log
 StandardError=inherit
 
 # Sandboxing options to harden security
+# Depending on specificities of your service/app, you may need to tweak these 
+# .. but this should be a good baseline
 # Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
 NoNewPrivileges=yes
 PrivateTmp=yes

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
         "nginx"
     ],
     "arguments": {
-        "install" : [
+        "install": [
             {
                 "name": "domain",
                 "type": "domain"

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Automated subtitle downloading for Sonarr and Radarr",
         "fr": "Téléchargement automatique de sous-titres pour Sonarr et Radarr"
     },
-    "version": "1.0.1~ynh1",
+    "version": "1.0.1~ynh2",
     "url": "https://bazarr.media",
     "upstream": {
         "license": "GPL-3.0",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,15 +7,9 @@
 python_version="3.7"
 python_major_version=$(echo $python_version | cut -d. -f1)
 
-# dependencies used by the app
-if [[ $YNH_ARCH != arm* ]]
-then
-	pkg_dependencies="libxml2-dev libxslt1-dev python3-dev python3-libxml2 python3-lxml unrar-free ffmpeg libatlas-base-dev"
-else
-	pkg_dependencies="libxml2-dev libxslt1-dev python3-dev python3-libxml2 python3-lxml unrar-free ffmpeg libatlas-base-dev"
-fi
-
-pkg_dependencies+=" python${python_major_version}-venv"
+pkg_dependencies="libxml2-dev libxslt1-dev unrar-free ffmpeg libatlas-base-dev"
+pkg_dependencies+=" python${python_major_version}-libxml2 python${python_major_version}-lxml"
+pkg_dependencies+=" python${python_major_version}-dev python${python_major_version}-venv"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/backup
+++ b/scripts/backup
@@ -15,7 +15,6 @@ source /usr/share/yunohost/helpers
 #=================================================
 
 ynh_clean_setup () {
-	### Remove this function if there's nothing to clean before calling the remove script.
 	true
 }
 # Exit if an error occurs during the execution of the script

--- a/scripts/install
+++ b/scripts/install
@@ -117,6 +117,14 @@ pushd $final_path
 popd
 
 #=================================================
+# SETUP SYSTEMD
+#=================================================
+ynh_script_progression --message="Configuring a systemd service..." --weight=1
+
+# Create a dedicated systemd config
+ynh_add_systemd_config
+
+#=================================================
 # ADD A CONFIGURATION
 #=================================================
 ynh_script_progression --message="Adding a configuration file..." --weight=1
@@ -138,14 +146,6 @@ ynh_add_config --template="config.ini" --destination="$final_path/data/config/co
 
 chmod 660 "$final_path/data/config/config.ini"
 chown $app: "$final_path/data/config/config.ini"
-
-#=================================================
-# SETUP SYSTEMD
-#=================================================
-ynh_script_progression --message="Configuring a systemd service..." --weight=1
-
-# Create a dedicated systemd config
-ynh_add_systemd_config
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION

--- a/scripts/install
+++ b/scripts/install
@@ -146,6 +146,16 @@ chmod 660 "$final_path/data/config/config.ini"
 chown $app: "$final_path/data/config/config.ini"
 
 #=================================================
+# YUNOHOST MULTIMEDIA INTEGRATION
+#=================================================
+ynh_script_progression --message="Adding multimedia directories..." --weight=1
+
+# Build YunoHost multimedia directories
+ynh_multimedia_build_main_dir
+# Enable writing into these directories
+ynh_multimedia_addaccess $app
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SETUP LOGROTATE

--- a/scripts/install
+++ b/scripts/install
@@ -138,7 +138,10 @@ ynh_systemd_action --service_name=$app --action="stop" --line_match="Bazarr exit
 detect_and_read_radarr_and_sonarr_settings
 
 flask_key=$(ynh_string_random --length=32)
+ynh_app_setting_set --app=$app --key=flask_key --value=$flask_key
+
 api_key=$(ynh_string_random --length=32)
+ynh_app_setting_set --app=$app --key=api_key --value=$api_key
 
 ynh_add_config --template="config.ini" --destination="$final_path/data/config/config.ini"
 

--- a/scripts/install
+++ b/scripts/install
@@ -112,7 +112,7 @@ ynh_script_progression --message="Installing Bazarr and its dependencies..." --w
 
 pushd $final_path
         # Initialize virtual environment
-        ynh_exec_as $app python${python_version} -m venv venv
+        ynh_exec_as $app python${python_major_version} -m venv venv
 
         ynh_exec_as $app $final_path/venv/bin/pip install -r "$final_path/requirements.txt"
 popd

--- a/scripts/install
+++ b/scripts/install
@@ -14,7 +14,6 @@ source /usr/share/yunohost/helpers
 #=================================================
 
 ynh_clean_setup () {
-	### Remove this function if there's nothing to clean before calling the remove script.
 	true
 }
 # Exit if an error occurs during the execution of the script
@@ -118,14 +117,6 @@ pushd $final_path
 popd
 
 #=================================================
-# SETUP SYSTEMD
-#=================================================
-ynh_script_progression --message="Configuring a systemd service..." --weight=1
-
-# Create a dedicated systemd config
-ynh_add_systemd_config
-
-#=================================================
 # ADD A CONFIGURATION
 #=================================================
 ynh_script_progression --message="Adding a configuration file..." --weight=1
@@ -147,6 +138,14 @@ ynh_add_config --template="config.ini" --destination="$final_path/data/config/co
 
 chmod 660 "$final_path/data/config/config.ini"
 chown $app: "$final_path/data/config/config.ini"
+
+#=================================================
+# SETUP SYSTEMD
+#=================================================
+ynh_script_progression --message="Configuring a systemd service..." --weight=1
+
+# Create a dedicated systemd config
+ynh_add_systemd_config
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -50,14 +50,6 @@ ynh_script_progression --message="Removing logrotate configuration..." --weight=
 ynh_remove_logrotate
 
 #=================================================
-# REMOVE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Removing dependencies..." --weight=2
-
-# Remove metapackage and its dependencies
-ynh_remove_app_dependencies
-
-#=================================================
 # REMOVE APP MAIN DIR
 #=================================================
 ynh_script_progression --message="Removing app main directory..." --weight=1
@@ -72,6 +64,14 @@ ynh_script_progression --message="Removing NGINX web server configuration..." --
 
 # Remove the dedicated NGINX config
 ynh_remove_nginx_config
+
+#=================================================
+# REMOVE DEPENDENCIES
+#=================================================
+ynh_script_progression --message="Removing dependencies..." --weight=2
+
+# Remove metapackage and its dependencies
+ynh_remove_app_dependencies
 
 #=================================================
 # SPECIFIC REMOVE

--- a/scripts/restore
+++ b/scripts/restore
@@ -15,7 +15,6 @@ source /usr/share/yunohost/helpers
 #=================================================
 
 ynh_clean_setup () {
-	#### Remove this function if there's nothing to clean before calling the remove script.
 	true
 }
 # Exit if an error occurs during the execution of the script

--- a/scripts/restore
+++ b/scripts/restore
@@ -99,6 +99,16 @@ ynh_restore_file --origin_path="/etc/systemd/system/$app.service"
 systemctl enable $app.service --quiet
 
 #=================================================
+# YUNOHOST MULTIMEDIA INTEGRATION
+#=================================================
+ynh_script_progression --message="Adding multimedia directories..." --weight=1
+
+# Build YunoHost multimedia directories
+ynh_multimedia_build_main_dir
+# Enable writing into these directories
+ynh_multimedia_addaccess $app
+
+#=================================================
 # RESTORE THE LOGROTATE CONFIGURATION
 #=================================================
 ynh_script_progression --message="Restoring the logrotate configuration..." --weight=1

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,7 +114,7 @@ ynh_script_progression --message="Upgrading Bazarr and its dependencies..." --we
 
 pushd $final_path
         # Initialize virtual environment
-        ynh_exec_as $app python${python_version} -m venv venv
+        ynh_exec_as $app python${python_major_version} -m venv venv
 
         ynh_exec_as $app $final_path/venv/bin/pip install -r "$final_path/requirements.txt"
 popd

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -27,6 +27,7 @@ detect_and_read_radarr_and_sonarr_settings
 #=================================================
 # CHECK VERSION
 #=================================================
+ynh_script_progression --message="Checking version..."
 
 upgrade_type=$(ynh_check_app_version_changed)
 
@@ -52,12 +53,6 @@ ynh_abort_if_errors
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
 ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
-
-#=================================================
-# ENSURE DOWNWARD COMPATIBILITY
-#=================================================
-#ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
-
 
 #=================================================
 # CREATE DEDICATED USER

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -130,6 +130,16 @@ chmod 660 "$final_path/data/config/config.ini"
 chown $app: "$final_path/data/config/config.ini"
 
 #=================================================
+# YUNOHOST MULTIMEDIA INTEGRATION
+#=================================================
+ynh_script_progression --message="Adding multimedia directories..." --weight=1
+
+# Build YunoHost multimedia directories
+ynh_multimedia_build_main_dir
+# Enable writing into these directories
+ynh_multimedia_addaccess $app
+
+#=================================================
 # SETUP SYSTEMD
 #=================================================
 ynh_script_progression --message="Upgrading systemd configuration..." --weight=1


### PR DESCRIPTION
## Solution

- *Add support for multimedia directories*
- *Apply last example_ynh*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
