### PR TITLE
Use major version for Python call

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,15 +7,9 @@
 python_version="3.7"
 python_major_version=$(echo $python_version | cut -d. -f1)
 
-# dependencies used by the app
-if [[ $YNH_ARCH != arm* ]]
-then
-	pkg_dependencies="libxml2-dev libxslt1-dev python3-dev python3-libxml2 python3-lxml unrar-free ffmpeg libatlas-base-dev"
-else
-	pkg_dependencies="libxml2-dev libxslt1-dev python3-dev python3-libxml2 python3-lxml unrar-free ffmpeg libatlas-base-dev"
-fi
-
-pkg_dependencies+=" python${python_major_version}-venv"
+pkg_dependencies="libxml2-dev libxslt1-dev unrar-free ffmpeg libatlas-base-dev"
+pkg_dependencies+=" python${python_major_version}-libxml2 python${python_major_version}-lxml"
+pkg_dependencies+=" python${python_major_version}-dev python${python_major_version}-venv"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -112,7 +112,7 @@ ynh_script_progression --message="Installing Bazarr and its dependencies..." --w
 
 pushd $final_path
         # Initialize virtual environment
-        ynh_exec_as $app python${python_version} -m venv venv
+        ynh_exec_as $app python${python_major_version} -m venv venv
 
         ynh_exec_as $app $final_path/venv/bin/pip install -r "$final_path/requirements.txt"
 popd

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,7 +114,7 @@ ynh_script_progression --message="Upgrading Bazarr and its dependencies..." --we
 
 pushd $final_path
         # Initialize virtual environment
-        ynh_exec_as $app python${python_version} -m venv venv
+        ynh_exec_as $app python${python_major_version} -m venv venv
 
         ynh_exec_as $app $final_path/venv/bin/pip install -r "$final_path/requirements.txt"
 popd


### PR DESCRIPTION
## Problem

`python3.7` does not exist in Bullseye

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
