### PR TITLE
Load standard environment PATH for service and do not overwrite config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Bazarr is a companion application to Sonarr and Radarr that manages and download
 - Subtitles upgrade whenever better ones are released
 
 
-**Shipped version:** 1.0.1~ynh2
+**Shipped version:** 1.0.1~ynh3
 
 
 
@@ -34,8 +34,7 @@ Bazarr is a companion application to Sonarr and Radarr that manages and download
 
 ## Disclaimers / important information
 
-- If Radarr or Sonarr are installed on your server, the app will automatically retrieve their settings and integrate them in its config.
-  - If you add or remove them afterwards, force an upgrade of Bazarr: it will update its settings again.
+- If Radarr or Sonarr are installed beforehand on your server, the app will automatically retrieve their settings and integrate them in its config.
 - Enabling Auto-updating in the settings is discouraged and no support will be provided if you do so.
 
 ## Documentation and resources

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Bazarr is a companion application to Sonarr and Radarr that manages and download
 - Subtitles upgrade whenever better ones are released
 
 
-**Version incluse :** 1.0.1~ynh2
+**Version incluse :** 1.0.1~ynh3
 
 
 
@@ -30,8 +30,7 @@ Bazarr is a companion application to Sonarr and Radarr that manages and download
 
 ## Avertissements / informations importantes
 
-- If Radarr or Sonarr are installed on your server, the app will automatically retrieve their settings and integrate them in its config.
-  - If you add or remove them afterwards, force an upgrade of Bazarr: it will update its settings again.
+- If Radarr or Sonarr are installed beforehand on your server, the app will automatically retrieve their settings and integrate them in its config.
 - Enabling Auto-updating in the settings is discouraged and no support will be provided if you do so.
 
 ## Documentations et ressources

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 Environment=PYTHONUNBUFFERED=1
-Environment=PATH=__FINALPATH__/venv/bin
+Environment=PATH=__ENV_PATH__
 WorkingDirectory=__FINALPATH__/
 ExecStart=__FINALPATH__/venv/bin/python bazarr.py
 StandardOutput=append:/var/log/__APP__/__APP__.log

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,3 +1,2 @@
-- If Radarr or Sonarr are installed on your server, the app will automatically retrieve their settings and integrate them in its config.
-  - If you add or remove them afterwards, force an upgrade of Bazarr: it will update its settings again.
+- If Radarr or Sonarr are installed beforehand on your server, the app will automatically retrieve their settings and integrate them in its config.
 - Enabling Auto-updating in the settings is discouraged and no support will be provided if you do so.

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Automated subtitle downloading for Sonarr and Radarr",
         "fr": "Téléchargement automatique de sous-titres pour Sonarr et Radarr"
     },
-    "version": "1.0.1~ynh2",
+    "version": "1.0.1~ynh3",
     "url": "https://bazarr.media",
     "upstream": {
         "license": "GPL-3.0",

--- a/scripts/install
+++ b/scripts/install
@@ -121,6 +121,8 @@ popd
 #=================================================
 ynh_script_progression --message="Configuring a systemd service..." --weight=1
 
+env_path="$final_path/venv/bin:$PATH"
+
 # Create a dedicated systemd config
 ynh_add_systemd_config
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -139,6 +139,8 @@ ynh_multimedia_addaccess $app
 #=================================================
 ynh_script_progression --message="Upgrading systemd configuration..." --weight=1
 
+env_path="$final_path/venv/bin:$PATH"
+
 # Create a dedicated systemd config
 ynh_add_systemd_config
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -117,12 +117,13 @@ popd
 #=================================================
 # UPDATE A CONFIG FILE
 #=================================================
-ynh_script_progression --message="Updating a configuration file..." --weight=1
+#FIXME: Find a way not to override all settings while upgrading the config file.
+#ynh_script_progression --message="Updating a configuration file..." --weight=1
 
-ynh_add_config --template="config.ini" --destination="$final_path/data/config/config.ini"
+#ynh_add_config --template="config.ini" --destination="$final_path/data/config/config.ini"
 
-chmod 660 "$final_path/data/config/config.ini"
-chown $app: "$final_path/data/config/config.ini"
+#chmod 660 "$final_path/data/config/config.ini"
+#chown $app: "$final_path/data/config/config.ini"
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION


### PR DESCRIPTION
## Problem

- Bazarr needs `ffprobe` among other external binaries, so the full PATH needs to be loaded.
- Config file was being overwritten, making the user lose their parameters.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
