### PR TITLE
Allow access to API through ssowat

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -55,6 +55,10 @@ ram.runtime = "50M"
     [resources.permissions]
     main.url = "/"
     main.allowed = "admins"
+    api.url = "/api"
+    api.allowed = "visitors"
+    api.show_tile = false
+    api.protected = true
 
     [resources.apt]
     packages = "libxml2-dev, libxslt1-dev, unar, ffmpeg, libatlas-base-dev, python3-venv"


### PR DESCRIPTION
## Problem

- Bazarr API cannot be accessed like Radarr/Sonarr/Prowlarr API because entry is not set in SSOWAT

## Solution

- Add entry to SSOWAT

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
